### PR TITLE
fix: exclude type-only packages

### DIFF
--- a/script/crawl.js
+++ b/script/crawl.js
@@ -175,13 +175,17 @@ function analyzePackument(result) {
   }
 
   // If there are no explicit exports:
-  if (cjs === undefined && esm === undefined) {
-    if (type === 'module' || (main && /\.mjs$/.test(main))) {
+  if (cjs === undefined && esm === undefined && main) {
+    if (type === 'module' || /\.mjs$/.test(main)) {
       esm = true
     } else {
       cjs = true
     }
   }
+
+  // No `main` or `exports` or `module` or `type`, likely a type-only or cli-only package
+  if (!esm && !cjs)
+    return undefined
 
   /** @type {Style} */
   const style = esm && cjs ? 'dual' : esm ? 'esm' : fauxEsm ? 'faux' : 'cjs'


### PR DESCRIPTION
For example, with the current algorithm, `type-fest` is considered CJS, which it's actually a type-only package:
https://github.com/sindresorhus/type-fest/blob/bf5ce3cad372967a25e6ecaa92d65efa86ab7c71/package.json#L13